### PR TITLE
Switch from kw syntax to nested dict update to please mypy

### DIFF
--- a/stringcalc/frets.py
+++ b/stringcalc/frets.py
@@ -88,19 +88,22 @@ def distances(N: int, *, L: float, method: str = "et") -> pd.DataFrame:
     # TODO: comparison to just intonation for specified root
 
     df = pd.DataFrame({"n": n, "d": d, "dd": dd, "d_inv": L - d}).set_index("n")
-    desc = {
-        "n": "fret number",
-        "d": "distance from nut to fret",
-        "dd": "distance from previous fret to current",
-        "d_inv": "distance from fret to saddle",
-    }
-    fancy_col = {
-        "n": "n",
-        "d": "d",
-        "dd": "Δd",
-        "d_inv": "L−d",
-    }
-    df.attrs.update(col_desc=desc, fancy_col=fancy_col)
+    df.attrs.update(
+        {
+            "col_desc": {
+                "n": "fret number",
+                "d": "distance from nut to fret",
+                "dd": "distance from previous fret to current",
+                "d_inv": "distance from fret to saddle",
+            },
+            "fancy_col": {
+                "n": "n",
+                "d": "d",
+                "dd": "Δd",
+                "d_inv": "L−d",
+            },
+        }
+    )
 
     return df
 

--- a/stringcalc/tension.py
+++ b/stringcalc/tension.py
@@ -553,16 +553,19 @@ def suggest_gauge(
         )
 
     df = data_sort[["id", "T", "dT"]].sort_values(by="dT").reset_index(drop=True)
-    desc = {
-        "id": "Product ID",
-        "T": "Tension",
-        "dT": "Tension difference from target tension",
-    }
-    fancy_col = {
-        "id": "ID",
-        "T": "T",
-        "dT": "ΔT",
-    }
-    df.attrs.update(col_desc=desc, fancy_col=fancy_col)
+    df.attrs.update(
+        {
+            "col_desc": {
+                "id": "Product ID",
+                "T": "Tension",
+                "dT": "Tension difference from target tension",
+            },
+            "fancy_col": {
+                "id": "ID",
+                "T": "T",
+                "dT": "ΔT",
+            },
+        }
+    )
 
     return df


### PR DESCRIPTION
recently started getting this with mypy 1.17.1, possibly due to a change in typeshed (where dict is typed)

`error: No overload variant of "update" of "MutableMapping" matches argument types "dict[str, str]", "dict[str, str]"  [call-overload]`